### PR TITLE
Update dependency for darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739214665,
-        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
         "type": "github"
       },
       "original": {

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738275749,
-        "narHash": "sha256-PM+cGduJ05EZ+YXulqAwUFjvfKpPmW080mcuN6R1POw=",
+        "lastModified": 1741635347,
+        "narHash": "sha256-2aYfV44h18alHXopyfL4D9GsnpE5XlSVkp4MGe586VU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a8159195bfaef3c64df75d3b1e6a68d49d392be9",
+        "rev": "7fb8678716c158642ac42f9ff7a18c0800fea551",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738277753,
-        "narHash": "sha256-iyFcCOk0mmDiv4ut9mBEuMxMZIym3++0qN1rQBg8FW0=",
+        "lastModified": 1741229100,
+        "narHash": "sha256-0HwrTDXp9buEwal/1ymK9uQmzUD5ozIA7CJGqnT/gLs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "49b807fa7c37568d7fbe2aeaafb9255c185412f9",
+        "rev": "adf5c88ba1fe21af5c083b4d655004431f20c5ab",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736095716,
-        "narHash": "sha256-csysw/Szu98QDiA2lhWk9seYOyCebeVEWL89zh1cduM=",
+        "lastModified": 1741192150,
+        "narHash": "sha256-wB140alXVla1Rw/kENerUoma2qO1Jy5IYWbmiSqmJu0=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "63c3b4ed1712a3a0621002cd59bfdc80875ecbb0",
+        "rev": "0e4ccdb8181da2c6193c047b50ffee5f1a3b6dc1",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738297584,
-        "narHash": "sha256-AYvaFBzt8dU0fcSK2jKD0Vg23K2eIRxfsVXIPCW9a0E=",
+        "lastModified": 1741462378,
+        "narHash": "sha256-ZF3YOjq+vTcH51S+qWa1oGA9FgmdJ67nTNPG2OIlXDc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9189ac18287c599860e878e905da550aa6dec1cd",
+        "rev": "2d9e4457f8e83120c9fdf6f1707ed0bc603e5ac9",
         "type": "github"
       },
       "original": {
@@ -124,11 +124,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1739262228,
-        "narHash": "sha256-7JAGezJ0Dn5qIyA2+T4Dt/xQgAbhCglh6lzCekTVMeU=",
+        "lastModified": 1741644481,
+        "narHash": "sha256-E0RrMykMtEv15V3QhpsFutgoSKhL1JBhidn+iZajOyg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "07af005bb7d60c7f118d9d9f5530485da5d1e975",
+        "rev": "e653d71e82575a43fe9d228def8eddb73887b866",
         "type": "github"
       },
       "original": {

--- a/nix/hosts/darwin/darwin.nix
+++ b/nix/hosts/darwin/darwin.nix
@@ -4,7 +4,7 @@
   me,
   ...
 }: {
-  services.nix-daemon.enable = true;
+  nix.enable = true;
 
   #homebrew
   homebrew = {
@@ -40,8 +40,6 @@
       home = "${me.homePrefix}";
     };
   };
-  nix.configureBuildUsers = true;
-  nix.useDaemon = true;
 
   # Set Git commit hash for darwin-version.
   #system.configurationRevision = self.rev or self.dirtyRev or null;
@@ -74,7 +72,7 @@
   };
 
   # Enable sudo touch id authentication
-  security.pam.enableSudoTouchIdAuth = true;
+  security.pam.services.sudo_local.touchIdAuth = true;
 
   # The platform the configuration will be used on.
   nixpkgs.hostPlatform = "aarch64-darwin";

--- a/nix/modules/git.nix
+++ b/nix/modules/git.nix
@@ -21,6 +21,7 @@
       gpg.format = "ssh";
       commit.gpgSign = true;
       diff.external = "difft";
+      core.editor = "nvim";
     };
   };
 }


### PR DESCRIPTION
This pull request includes several changes to the Nix configuration files to update service settings and improve usability. The most important changes include enabling the Nix service, updating the configuration for sudo touch ID authentication, and setting the default editor for Git.

Updates to service settings:

* [`nix/hosts/darwin/darwin.nix`](diffhunk://#diff-65755c1ee91835032301ef3a82e9b7a621e83b2f82a4b4e41f1a68a69e351d97L7-R7): Enabled the Nix service by setting `nix.enable` to true instead of `services.nix-daemon.enable`.
* [`nix/hosts/darwin/darwin.nix`](diffhunk://#diff-65755c1ee91835032301ef3a82e9b7a621e83b2f82a4b4e41f1a68a69e351d97L43-L44): Removed the `nix.configureBuildUsers` and `nix.useDaemon` settings, which are no longer needed.

Improvements to usability:

* [`nix/hosts/darwin/darwin.nix`](diffhunk://#diff-65755c1ee91835032301ef3a82e9b7a621e83b2f82a4b4e41f1a68a69e351d97L77-R75): Updated the configuration for sudo touch ID authentication to use `security.pam.services.sudo_local.touchIdAuth` instead of `security.pam.enableSudoTouchIdAuth`.
* [`nix/modules/git.nix`](diffhunk://#diff-b80ee126ce99dadc795eecc0ff52e6da1dae8ae18c6ae1996ae072a4a772d904R24): Set the default Git editor to `nvim` by adding `core.editor = "nvim"`.