### PR TITLE
feat: simplify sessionizer and add wt worktree module

### DIFF
--- a/hosts/home.nix
+++ b/hosts/home.nix
@@ -16,6 +16,7 @@
     lazyvim.enable = true;
     tmux.enable = true;
     tmux-sessionizer.enable = true;
+    wt.enable = true;
     opencode.enable = true;
     plannotator.enable = true;
     agent-config.enable = true;

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -12,6 +12,7 @@
     ./lazyvim.nix
     ./tmux.nix
     ./tmux-sessionizer.nix
+    ./wt.nix
     ./opencode.nix
     ./plannotator.nix
     ./agent-config.nix

--- a/modules/home/portable.nix
+++ b/modules/home/portable.nix
@@ -18,6 +18,7 @@
     ./lazyvim.nix
     ./tmux.nix
     ./tmux-sessionizer.nix
+    ./wt.nix
     ./opencode.nix
     ./plannotator.nix
     ./agent-config.nix
@@ -46,6 +47,7 @@
     lazyvim.enable = true;
     tmux.enable = true;
     tmux-sessionizer.enable = true;
+    wt.enable = true;
     opencode.enable = true;
     plannotator.enable = true;
     agent-config.enable = true;

--- a/modules/home/starship.nix
+++ b/modules/home/starship.nix
@@ -16,6 +16,27 @@ in {
       enableZshIntegration = config.myModules.home.zsh.enable && !portable;
       enableFishIntegration = config.myModules.home.fish.enable;
       settings = {
+        format = "$custom$all";
+
+        custom.worktree_context = {
+          command = ''
+            root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 1
+            main_root="$(git -C "$root" worktree list --porcelain 2>/dev/null | awk '/^worktree / { sub(/^worktree /, ""); print; exit }')"
+            if [ -z "$main_root" ] || [ "$root" = "$main_root" ]; then
+              exit 1
+            fi
+
+            repo="$(basename "$main_root")"
+            worktree="$(basename "$root")"
+            printf '%s/%s' "$repo" "$worktree"
+          '';
+          when = ''
+            git rev-parse --show-toplevel >/dev/null 2>&1
+          '';
+          format = "[$output]($style) ";
+          style = "bold mauve";
+        };
+
         aws = {
           symbol = "  ";
         };

--- a/modules/home/starship.nix
+++ b/modules/home/starship.nix
@@ -16,27 +16,6 @@ in {
       enableZshIntegration = config.myModules.home.zsh.enable && !portable;
       enableFishIntegration = config.myModules.home.fish.enable;
       settings = {
-        format = "$custom$all";
-
-        custom.worktree_context = {
-          command = ''
-            root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 1
-            main_root="$(git -C "$root" worktree list --porcelain 2>/dev/null | awk '/^worktree / { sub(/^worktree /, ""); print; exit }')"
-            if [ -z "$main_root" ] || [ "$root" = "$main_root" ]; then
-              exit 1
-            fi
-
-            repo="$(basename "$main_root")"
-            worktree="$(basename "$root")"
-            printf '%s/%s' "$repo" "$worktree"
-          '';
-          when = ''
-            git rev-parse --show-toplevel >/dev/null 2>&1
-          '';
-          format = "[$output]($style) ";
-          style = "bold mauve";
-        };
-
         aws = {
           symbol = "  ";
         };

--- a/modules/home/tmux-sessionizer.nix
+++ b/modules/home/tmux-sessionizer.nix
@@ -9,6 +9,7 @@
 
   searchPathsStr = lib.concatStringsSep " " cfg.searchPaths;
   extraPathsStr = lib.concatStringsSep " " (cfg.extraPaths or []);
+  wtWorktreeDirStr = lib.replaceStrings ["~"] ["$HOME"] cfg.wtWorktreeDir;
 
   tmux-sessionizer = pkgs.writeShellScriptBin "tmux-sessionizer" ''
 
@@ -22,6 +23,9 @@
 
     # Extra paths that aren't git repos (shown as-is)
     TS_EXTRA_PATHS=(${extraPathsStr})
+
+    # Worktree store root used for repo-aware session naming
+    TS_WT_WORKTREE_DIR="${wtWorktreeDirStr}"
 
     # Default max depth for paths without explicit depth
     TS_MAX_DEPTH=2
@@ -141,10 +145,13 @@
         if [[ -n "$session_cmd" ]]; then
             return
         fi
+        local source_cmd
         if [ -f "$2/.tmux-sessionizer" ]; then
-            tmux send-keys -t "$1" "source $2/.tmux-sessionizer" C-m
+            printf -v source_cmd 'source %q' "$2/.tmux-sessionizer"
+            tmux send-keys -t "$1" "$source_cmd" C-m
         elif [ -f "$HOME/.tmux-sessionizer" ]; then
-            tmux send-keys -t "$1" "source $HOME/.tmux-sessionizer" C-m
+            printf -v source_cmd 'source %q' "$HOME/.tmux-sessionizer"
+            tmux send-keys -t "$1" "$source_cmd" C-m
         fi
     }
 
@@ -158,6 +165,54 @@
     init_pane_cache() {
         mkdir -p "$PANE_CACHE_DIR"
         touch "$PANE_CACHE_FILE"
+    }
+
+    emit_entry() {
+        printf '%s\t%s\n' "$1" "$2"
+    }
+
+    main_repo_root() {
+        local path="$1"
+        local line
+
+        while IFS= read -r line; do
+            case "$line" in
+            worktree\ *)
+                printf '%s\n' "''${line#worktree }"
+                return 0
+                ;;
+            esac
+        done < <(git -C "$path" worktree list --porcelain 2>/dev/null)
+
+        return 1
+    }
+
+    is_managed_worktree_dir() {
+        local path="$1"
+        local wt_root="''${TS_WT_WORKTREE_DIR%/}"
+        [[ "$path" == "$wt_root" || "$path" == "$wt_root"/* ]]
+    }
+
+    is_worktree_path() {
+        local path="$1"
+        local main_root
+        main_root=$(main_repo_root "$path") || return 1
+        [[ "$path" != "$main_root" ]]
+    }
+
+    session_name_for_path() {
+        local path="$1"
+        local main_root
+        main_root=$(main_repo_root "$path" 2>/dev/null || true)
+
+        if [[ -n "$main_root" && "$path" != "$main_root" ]]; then
+            local repo_name worktree_name
+            repo_name=$(basename "$main_root" | tr '. ' '_')
+            worktree_name=$(basename "$path" | tr '. ' '_')
+            printf '%s/%s\n' "$repo_name" "$worktree_name"
+        else
+            basename "$path" | tr '. ' '_'
+        fi
     }
 
     get_pane_id() {
@@ -199,13 +254,21 @@
     # Get all worktrees for a given repo path
     get_worktrees() {
         local repo_path="$1"
-        git -C "$repo_path" worktree list --porcelain 2>/dev/null | while read -r line; do
+        local repo_root
+        repo_root=$(main_repo_root "$repo_path" 2>/dev/null || true)
+        if [[ -z "$repo_root" || "$repo_path" != "$repo_root" ]]; then
+            return 0
+        fi
+        local repo_name
+        repo_name=$(basename "$repo_root")
+        git -C "$repo_root" worktree list --porcelain 2>/dev/null | while read -r line; do
             if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
                 local wt_path="''${BASH_REMATCH[1]}"
                 # Skip the main repo itself
-                if [[ "$wt_path" != "$repo_path" ]]; then
-                    local wt_name=$(basename "$wt_path")
-                    echo "''${repo_path}/''${wt_name}"
+                if [[ "$wt_path" != "$repo_root" ]]; then
+                    local wt_name
+                    wt_name=$(basename "$wt_path")
+                    emit_entry "worktree/''${repo_name}/''${wt_name}" "$wt_path"
                 fi
             fi
         done
@@ -216,9 +279,13 @@
         # List TMUX sessions first
         if [[ -n "''${TMUX}" ]]; then
             current_session=$(tmux display-message -p '#S')
-            tmux list-sessions -F "[TMUX] #{session_name}" 2>/dev/null | grep -vFx "[TMUX] $current_session"
+            tmux list-sessions -F "#{session_name}" 2>/dev/null | grep -vFx "$current_session" | while read -r session; do
+                emit_entry "[TMUX] $session" "[TMUX] $session"
+            done
         else
-            tmux list-sessions -F "[TMUX] #{session_name}" 2>/dev/null
+            tmux list-sessions -F "#{session_name}" 2>/dev/null | while read -r session; do
+                emit_entry "[TMUX] $session" "[TMUX] $session"
+            done
         fi
 
         # Process each search path
@@ -234,24 +301,53 @@
 
             [[ -d "$path" ]] || continue
 
+            if is_managed_worktree_dir "$path"; then
+                continue
+            fi
+
             # Check if this is a git repo
-            if [[ -d "$path/.git" ]]; then
+            if [[ -e "$path/.git" ]]; then
                 # It's a git repo - show it and its worktrees
-                echo "$path"
-                get_worktrees "$path"
+                if is_worktree_path "$path"; then
+                    continue
+                fi
+
+                repo_root=$(main_repo_root "$path" 2>/dev/null || true)
+                if [[ -z "$repo_root" ]]; then
+                    continue
+                fi
+
+                emit_entry "$repo_root" "$repo_root"
+                get_worktrees "$repo_root"
+                continue
             elif [[ -d "$path/.bare" ]]; then
                 # Bare repo - just show it
-                echo "$path"
+                emit_entry "$path" "$path"
+                continue
             else
                 # Non-git directory - show as-is
-                echo "$path"
+                emit_entry "$path" "$path"
             fi
 
             # Search for git repos within this path
-            find "$path" -mindepth 1 -maxdepth "''${depth}" -type d 2>/dev/null | while read -r dir; do
-                if [[ -d "$dir/.git" ]]; then
-                    echo "$dir"
-                    get_worktrees "$dir"
+            find "$path" -mindepth 1 -maxdepth "''${depth}" -type d \
+                \( -exec test -e "{}/.git" \; -o -exec test -d "{}/.bare" \; \) \
+                -print -prune 2>/dev/null | while read -r dir; do
+                if is_managed_worktree_dir "$dir"; then
+                    continue
+                fi
+                if is_worktree_path "$dir"; then
+                    continue
+                fi
+                if [[ -e "$dir/.git" ]]; then
+                    repo_root=$(main_repo_root "$dir" 2>/dev/null || true)
+                    if [[ -z "$repo_root" ]]; then
+                        continue
+                    fi
+                    emit_entry "$repo_root" "$repo_root"
+                    get_worktrees "$repo_root"
+                elif [[ -d "$dir/.bare" ]]; then
+                    emit_entry "$dir" "$dir"
                 fi
             done
         done
@@ -321,23 +417,26 @@
     elif [[ -n "$user_selected" ]]; then
         selected="$user_selected"
     else
-        selected=$(find_dirs | fzf)
+        selected=$(find_dirs | fzf --delimiter=$'\t' --with-nth=1)
     fi
 
     [[ -z "$selected" ]] && exit 0
 
+    selected_label="''${selected%%$'\t'*}"
+    selected_value="''${selected#*$'\t'}"
+    if [[ "$selected_label" == "$selected_value" ]]; then
+        selected_value="$selected_label"
+    fi
+
     # Handle [TMUX] session selection
-    if [[ "$selected" =~ ^\[TMUX\]\ (.+)$ ]]; then
+    if [[ "$selected_label" =~ ^\[TMUX\]\ (.+)$ ]]; then
         switch_to "''${BASH_REMATCH[1]}"
         exit 0
     fi
 
-    # Handle worktree selection (parent/worktree format)
-    if [[ "$selected" =~ ^(.+)/([^/]+)$ ]]; then
-        selected_name="''${BASH_REMATCH[2]}"
-    else
-        selected_name=$(basename "$selected" | tr '. ' '_')
-    fi
+    selected="$selected_value"
+
+    selected_name=$(session_name_for_path "$selected")
 
     if ! is_tmux_running; then
         tmux new-session -ds "$selected_name" -c "$selected"
@@ -355,7 +454,7 @@ in {
 
     searchPaths = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = ["$HOME/Documents:3"];
+      default = ["$HOME/dotfiles" "$HOME/Documents:3"];
       description = "List of paths to search for git repositories. Format: path:depth";
     };
 

--- a/modules/home/tmux-sessionizer.nix
+++ b/modules/home/tmux-sessionizer.nix
@@ -8,93 +8,7 @@
   portable = config.myModules.home.portable or false;
 
   searchPathsStr = lib.concatStringsSep " " cfg.searchPaths;
-
-  # Convert hex string to integer
-  hexToInt = hex: let
-    hexChars = {
-      "0" = 0;
-      "1" = 1;
-      "2" = 2;
-      "3" = 3;
-      "4" = 4;
-      "5" = 5;
-      "6" = 6;
-      "7" = 7;
-      "8" = 8;
-      "9" = 9;
-      "a" = 10;
-      "b" = 11;
-      "c" = 12;
-      "d" = 13;
-      "e" = 14;
-      "f" = 15;
-    };
-    chars = lib.stringToCharacters (lib.toLower hex);
-  in
-    lib.foldl (acc: c: acc * 16 + hexChars.${c}) 0 chars;
-
-  # Convert hex color to RGB ANSI escape sequence
-  hexToAnsi = hex: let
-    r = hexToInt (builtins.substring 0 2 hex);
-    g = hexToInt (builtins.substring 2 2 hex);
-    b = hexToInt (builtins.substring 4 2 hex);
-  in "\\033[1;38;2;${toString r};${toString g};${toString b}m";
-
-  # Catppuccin Macchiato colors
-  prefixColor = hexToAnsi "c6a0f6";
-  greenColor = hexToAnsi "a6da95";
-  redColor = hexToAnsi "ed8796";
-  subtextColor = hexToAnsi "a5adcb";
-
-  # Git status script for tmux status bar
-  tmux-git-status = pkgs.writeShellScriptBin "tmux-git-status" ''
-    #!/usr/bin/env bash
-    # Usage: tmux-git-status [pane_current_path]
-    # Outputs: worktree_name [branch] +add -del
-
-    pane_path="''${1:-$(pwd)}"
-
-    cd "$pane_path" 2>/dev/null || exit 0
-
-    if ! git rev-parse --is-inside-work-tree &>/dev/null; then
-      basename "$pane_path"
-      exit 0
-    fi
-
-    # Get worktree name
-    wt_root=$(git rev-parse --show-toplevel 2>/dev/null)
-    if [[ -f "$wt_root/.git" ]]; then
-      # Linked worktree
-      gitdir=$(sed -n 's/^gitdir: //p' "$wt_root/.git" | head -n1)
-      wt_name=$(basename "$gitdir")
-    else
-      wt_name="main"
-    fi
-
-    # Get branch
-    branch=$(git symbolic-ref --short -q HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo "?")
-
-    # Get diff stats
-    diff_stats=$(git diff --numstat 2>/dev/null | awk '{add+=$1; del+=$2} END {printf "%d %d", add+0, del+0}')
-    staged_stats=$(git diff --cached --numstat 2>/dev/null | awk '{add+=$1; del+=$2} END {printf "%d %d", add+0, del+0}')
-
-    read -r unstaged_add unstaged_del <<< "$diff_stats"
-    read -r staged_add staged_del <<< "$staged_stats"
-
-    total_add=$((unstaged_add + staged_add))
-    total_del=$((unstaged_del + staged_del))
-
-    output="$wt_name"
-
-    if [[ $total_add -gt 0 || $total_del -gt 0 ]]; then
-      output="$output "
-      [[ $total_add -gt 0 ]] && output="$output#[fg=green]+$total_add#[fg=default]"
-      [[ $total_add -gt 0 && $total_del -gt 0 ]] && output="$output "
-      [[ $total_del -gt 0 ]] && output="$output#[fg=red]-$total_del#[fg=default]"
-    fi
-
-    echo "$output"
-  '';
+  extraPathsStr = lib.concatStringsSep " " (cfg.extraPaths or []);
 
   tmux-sessionizer = pkgs.writeShellScriptBin "tmux-sessionizer" ''
 
@@ -104,8 +18,10 @@
 
     # Search paths for git repositories with depth control
     # Format: path:depth (depth is optional, defaults to TS_MAX_DEPTH)
-    # Only directories containing .git will be shown
     TS_SEARCH_PATHS=(${searchPathsStr})
+
+    # Extra paths that aren't git repos (shown as-is)
+    TS_EXTRA_PATHS=(${extraPathsStr})
 
     # Default max depth for paths without explicit depth
     TS_MAX_DEPTH=2
@@ -141,7 +57,7 @@
     session_cmd=""
     user_selected=""
     split_type=""
-    VERSION="0.1.0"
+    VERSION="0.2.0"
 
     while [[ "$#" -gt 0 ]]; do
         case "$1" in
@@ -149,9 +65,9 @@
             echo "Usage: tmux-sessionizer [OPTIONS] [SEARCH_PATH]"
             echo "Options:"
             echo "  -h, --help             Display this help message"
-            echo "  -s, --session <name>   session command index."
-            echo "  --vsplit               Create vertical split (horizontal layout) for session command"
-            echo "  --hsplit               Create horizontal split (vertical layout) for session command"
+            echo "  -s, --session <idx>   Run session command by index"
+            echo "  --vsplit              Create vertical split for session command"
+            echo "  --hsplit              Create horizontal split for session command"
             exit 0
             ;;
         -s | --session)
@@ -162,17 +78,16 @@
             fi
 
             if [[ -z $TS_SESSION_COMMANDS ]]; then
-                echo "TS_SESSION_COMMANDS is not set.  Must have a command set to run when switching to a session"
+                echo "TS_SESSION_COMMANDS is not set. Must have commands configured."
                 exit 1
             fi
 
             if [[ -z "$session_idx" || "$session_idx" -lt 0 || "$session_idx" -ge "''${#TS_SESSION_COMMANDS[@]}" ]]; then
-                echo "Error: Invalid index. Please provide an index between 0 and $((''${#TS_SESSION_COMMANDS[@]} - 1))."
+                echo "Error: Invalid index. Please provide 0 to $((''${#TS_SESSION_COMMANDS[@]} - 1))."
                 exit 1
             fi
 
             session_cmd="''${TS_SESSION_COMMANDS[$session_idx]}"
-
             shift
             ;;
         --vsplit)
@@ -192,44 +107,49 @@
         shift
     done
 
-    log "tmux-sessionizer($VERSION): idx=$session_idx cmd=$session_cmd user_selected=$user_selected split_type=$split_type log=$TS_LOG log_file=$TS_LOG_FILE"
+    log "tmux-sessionizer($VERSION): idx=$session_idx cmd=$session_cmd user_selected=$user_selected split_type=$split_type"
 
-    # Validate split options are only used with session commands
     if [[ -n "$split_type" && -z "$session_idx" ]]; then
-        echo "Error: --vsplit and --hsplit can only be used with -s/--session option"
+        echo "Error: --vsplit and --hsplit require -s option"
         exit 1
     fi
 
     sanity_check() {
         if ! command -v tmux &>/dev/null; then
-            echo "tmux is not installed. Please install it first."
+            echo "tmux is not installed."
             exit 1
         fi
-
         if ! command -v fzf &>/dev/null; then
-            echo "fzf is not installed. Please install it first."
+            echo "fzf is not installed."
             exit 1
         fi
     }
 
     switch_to() {
         if [[ -z $TMUX ]]; then
-            log "attaching to session $1"
             tmux attach-session -t "$1"
         else
-            log "switching to session $1"
             tmux switch-client -t "$1"
         fi
     }
 
     has_session() {
-        tmux list-sessions | grep -q "^$1:"
+        tmux list-sessions 2>/dev/null | grep -q "^$1:"
+    }
+
+    hydrate() {
+        if [[ -n "$session_cmd" ]]; then
+            return
+        fi
+        if [ -f "$2/.tmux-sessionizer" ]; then
+            tmux send-keys -t "$1" "source $2/.tmux-sessionizer" C-m
+        elif [ -f "$HOME/.tmux-sessionizer" ]; then
+            tmux send-keys -t "$1" "source $HOME/.tmux-sessionizer" C-m
+        fi
     }
 
     is_tmux_running() {
-        tmux_running=$(pgrep tmux)
-
-        if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
+        if [[ -z $TMUX ]] && [[ -z $(pgrep tmux) ]]; then
             return 1
         fi
         return 0
@@ -252,132 +172,94 @@
         local split_type="$2"
         local pane_id="$3"
         init_pane_cache
-
-        # Remove existing entry if it exists
         grep -v "^''${session_idx}:''${split_type}:" "$PANE_CACHE_FILE" > "''${PANE_CACHE_FILE}.tmp" 2>/dev/null || true
         mv "''${PANE_CACHE_FILE}.tmp" "$PANE_CACHE_FILE"
-
-        # Add new entry
         echo "''${session_idx}:''${split_type}:''${pane_id}" >> "$PANE_CACHE_FILE"
     }
 
     cleanup_dead_panes() {
         init_pane_cache
         local temp_file="''${PANE_CACHE_FILE}.tmp"
-
         while IFS=: read -r idx split pane_id; do
             if tmux list-panes -a -F "#{pane_id}" 2>/dev/null | grep -q "^''${pane_id}$"; then
                 echo "''${idx}:''${split}:''${pane_id}" >> "$temp_file"
             fi
         done < "$PANE_CACHE_FILE"
-
         mv "$temp_file" "$PANE_CACHE_FILE" 2>/dev/null || touch "$PANE_CACHE_FILE"
     }
 
     sanity_check
 
-    # if TS_SEARCH_PATHS is not set use default
-    [[ -n "$TS_SEARCH_PATHS" ]] || TS_SEARCH_PATHS=(~/ ~/personal ~/personal/dev/env/.config)
+    [[ -n "$TS_SEARCH_PATHS" ]] || TS_SEARCH_PATHS=(~/Documents)
 
-    # Add any extra search paths to the TS_SEARCH_PATHS array
-    # e.g : EXTRA_SEARCH_PATHS=("$HOME/extra1:4" "$HOME/extra2")
-    # note : Path can be suffixed with :number to limit or extend the depth of the search for the Path
-
-    if [[ ''${#TS_EXTRA_SEARCH_PATHS[@]} -gt 0 ]]; then
-        TS_SEARCH_PATHS+=("''${TS_EXTRA_SEARCH_PATHS[@]}")
+    if [[ ''${#TS_EXTRA_PATHS[@]} -gt 0 ]]; then
+        TS_SEARCH_PATHS+=("''${TS_EXTRA_PATHS[@]}")
     fi
 
-    # ANSI color codes (from Stylix theme)
-    TMUX_PREFIX_COLOR="${prefixColor}"
-    RESET_COLOR="\033[0m"
+    # Get all worktrees for a given repo path
+    get_worktrees() {
+        local repo_path="$1"
+        git -C "$repo_path" worktree list --porcelain 2>/dev/null | while read -r line; do
+            if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
+                local wt_path="''${BASH_REMATCH[1]}"
+                # Skip the main repo itself
+                if [[ "$wt_path" != "$repo_path" ]]; then
+                    local wt_name=$(basename "$wt_path")
+                    echo "''${repo_path}/''${wt_name}"
+                fi
+            fi
+        done
+    }
 
-    # utility function to find directories
+    # Find all directories (git repos + worktrees + extra paths)
     find_dirs() {
-        # list TMUX sessions
+        # List TMUX sessions first
         if [[ -n "''${TMUX}" ]]; then
             current_session=$(tmux display-message -p '#S')
-            tmux list-sessions -F "#{session_name}" 2>/dev/null | grep -vFx "$current_session" | while read -r session; do
-                echo -e "''${TMUX_PREFIX_COLOR}[TMUX]''${RESET_COLOR} $session"
-            done
+            tmux list-sessions -F "[TMUX] #{session_name}" 2>/dev/null | grep -vFx "[TMUX] $current_session"
         else
-            tmux list-sessions -F "#{session_name}" 2>/dev/null | while read -r session; do
-                echo -e "''${TMUX_PREFIX_COLOR}[TMUX]''${RESET_COLOR} $session"
-            done
+            tmux list-sessions -F "[TMUX] #{session_name}" 2>/dev/null
         fi
 
-        # note: TS_SEARCH_PATHS is an array of paths to search for git repositories
-        # if the path ends with :number, it will search for repos with a max depth of number ;)
-        # if there is no number, it will search for repos with a max depth defined by TS_MAX_DEPTH or 1 if not set
+        # Process each search path
         for entry in "''${TS_SEARCH_PATHS[@]}"; do
-            # Check if entry as :number as suffix then adapt the maxdepth parameter
+            # Parse path:depth format
             if [[ "$entry" =~ ^([^:]+):([0-9]+)$ ]]; then
                 path="''${BASH_REMATCH[1]}"
                 depth="''${BASH_REMATCH[2]}"
             else
                 path="$entry"
+                depth="''${TS_MAX_DEPTH:-2}"
             fi
 
-            # Find directories that contain .git (directory only) or .bare (bare worktree pattern)
-            # We exclude .git FILES because those are worktrees inside a bare repo project
-            # The bare repo project itself (with .bare/) is what we want to show
-            if [[ -d "$path" ]]; then
-                # If the path itself is a git repo or bare repo project, include it
-                if [[ -d "$path/.git" ]] || [[ -d "$path/.bare" ]]; then
-                    echo "$path"
-                fi
-                # Search for git repos (.git directory) and bare repo projects (.bare directory)
-                # Exclude .git files (worktrees) - we only want the project roots
-                find "$path" -mindepth 1 -maxdepth "''${depth:-''${TS_MAX_DEPTH:-1}}" -type d \( -exec test -d "{}/.git" \; -o -exec test -d "{}/.bare" \; \) -print 2>/dev/null
+            [[ -d "$path" ]] || continue
+
+            # Check if this is a git repo
+            if [[ -d "$path/.git" ]]; then
+                # It's a git repo - show it and its worktrees
+                echo "$path"
+                get_worktrees "$path"
+            elif [[ -d "$path/.bare" ]]; then
+                # Bare repo - just show it
+                echo "$path"
+            else
+                # Non-git directory - show as-is
+                echo "$path"
             fi
+
+            # Search for git repos within this path
+            find "$path" -mindepth 1 -maxdepth "''${depth}" -type d 2>/dev/null | while read -r dir; do
+                if [[ -d "$dir/.git" ]]; then
+                    echo "$dir"
+                    get_worktrees "$dir"
+                fi
+            done
         done
     }
 
-    # Get canonical repo name from any path (works for worktrees and bare repos)
-    get_repo_session_name() {
-        local dir="$1"
-
-        # Check for bare repo pattern first (directory with .bare/)
-        if [[ -d "$dir/.bare" ]]; then
-            basename "$dir" | tr '. ' '__'
-            return 0
-        fi
-
-        if ! git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            basename "$dir" | tr '. ' '__'
-            return 0
-        fi
-
-        # Get the common git dir (shared across all worktrees)
-        local common
-        common=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null)
-
-        # Resolve relative path to absolute
-        if [[ "$common" != /* ]]; then
-            common=$(cd "$dir" && realpath -m "$common" 2>/dev/null || echo "$dir/$common")
-        fi
-
-        # For bare repo pattern: .bare is the common dir, use parent as project name
-        if [[ "$(basename "$common")" == ".bare" ]]; then
-            basename "$(dirname "$common")" | tr '. ' '__'
-            return 0
-        fi
-
-        # Get repo root from common dir
-        local repo_root
-        if [[ "$common" == */.git ]]; then
-            repo_root=$(dirname "$common")
-        else
-            repo_root="$common"
-        fi
-
-        # Create session name: repo_basename (sanitized)
-        basename "$repo_root" | tr '. ' '__'
-    }
-
     handle_session_cmd() {
-        log "executing session command $session_cmd with index $session_idx split_type=$split_type"
         if ! is_tmux_running; then
-            echo "Error: tmux is not running.  Please start tmux first before using session commands."
+            echo "Error: tmux is not running."
             exit 1
         fi
 
@@ -396,13 +278,12 @@
         start_index=$((69 + $session_idx))
         target="$current_session:$start_index"
 
-        log "target: $target command $session_cmd has-session=$(tmux has-session -t="$target" 2> /dev/null)"
-        if tmux has-session -t="$target" 2> /dev/null; then
+        if tmux has-session -t="$target" 2>/dev/null; then
             switch_to "$target"
         else
-            log "executing session command: tmux neww -dt $target $session_cmd"
-            tmux neww -dt $target "$session_cmd"
-            tmux select-window -t $target
+            tmux neww -dt "$target" "$session_cmd"
+            hydrate "$target" "$selected"
+            tmux select-window -t "$target"
         fi
     }
 
@@ -410,11 +291,9 @@
         local current_session="$1"
         cleanup_dead_panes
 
-        # Check if pane already exists
         local existing_pane_id=$(get_pane_id "$session_idx" "$split_type")
 
         if [[ -n "$existing_pane_id" ]] && tmux list-panes -a -F "#{pane_id}" 2>/dev/null | grep -q "^''${existing_pane_id}$"; then
-            log "switching to existing pane $existing_pane_id"
             tmux select-pane -t "$existing_pane_id"
             if [[ -z $TMUX ]]; then
                 tmux attach-session -t "$current_session"
@@ -422,51 +301,50 @@
                 tmux switch-client -t "$current_session"
             fi
         else
-            # Create new split
             local split_flag=""
             if [[ "$split_type" == "vsplit" ]]; then
-                split_flag="-h"  # horizontal layout (vertical split)
+                split_flag="-h"
             else
-                split_flag="-v"  # vertical layout (horizontal split)
+                split_flag="-v"
             fi
 
-            log "creating new split: tmux split-window $split_flag -c $(pwd) $session_cmd"
             local new_pane_id=$(tmux split-window $split_flag -c "$(pwd)" -P -F "#{pane_id}" "$session_cmd")
 
             if [[ -n "$new_pane_id" ]]; then
                 set_pane_id "$session_idx" "$split_type" "$new_pane_id"
-                log "created pane $new_pane_id for session_idx=$session_idx split_type=$split_type"
             fi
         fi
     }
 
-    if [[ ! -z $session_cmd ]]; then
+    if [[ -n "$session_cmd" ]]; then
         handle_session_cmd
-    elif [[ ! -z $user_selected ]]; then
+    elif [[ -n "$user_selected" ]]; then
         selected="$user_selected"
     else
-        selected=$(find_dirs | fzf --ansi)
+        selected=$(find_dirs | fzf)
     fi
 
-    if [[ -z $selected ]]; then
-        exit 0
-    fi
+    [[ -z "$selected" ]] && exit 0
 
-    # Handle existing tmux session selection
-    if [[ "$selected" =~ ^\[TMUX\][[:space:]](.+)$ ]]; then
+    # Handle [TMUX] session selection
+    if [[ "$selected" =~ ^\[TMUX\]\ (.+)$ ]]; then
         switch_to "''${BASH_REMATCH[1]}"
         exit 0
     fi
 
-    # Get canonical session name (uses repo root for worktrees)
-    selected_name=$(get_repo_session_name "$selected")
+    # Handle worktree selection (parent/worktree format)
+    if [[ "$selected" =~ ^(.+)/([^/]+)$ ]]; then
+        selected_name="''${BASH_REMATCH[2]}"
+    else
+        selected_name=$(basename "$selected" | tr '. ' '_')
+    fi
 
     if ! is_tmux_running; then
         tmux new-session -ds "$selected_name" -c "$selected"
-    fi
-
-    if ! has_session "$selected_name"; then
+        hydrate "$selected_name" "$selected"
+    elif ! has_session "$selected_name"; then
         tmux new-session -ds "$selected_name" -c "$selected"
+        hydrate "$selected_name" "$selected"
     fi
 
     switch_to "$selected_name"
@@ -477,24 +355,29 @@ in {
 
     searchPaths = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = ["$HOME/Documents:3" "$HOME/dotfiles"];
+      default = ["$HOME/Documents:3"];
       description = "List of paths to search for git repositories. Format: path:depth";
+    };
+
+    extraPaths = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = "Extra non-git directories to show in sessionizer";
+    };
+
+    wtWorktreeDir = lib.mkOption {
+      type = lib.types.str;
+      default = "~/.wt-worktrees";
+      description = "Directory where wt stores worktrees";
     };
   };
 
   config = lib.mkIf cfg.enable {
-    # For Nix systems, add to packages (goes into profile)
-    home.packages = lib.mkIf (!portable) [tmux-sessionizer tmux-git-status];
+    home.packages = lib.mkIf (!portable) [tmux-sessionizer];
 
-    # For portable systems, write to ~/.local/bin
     home.file.".local/bin/tmux-sessionizer" = lib.mkIf portable {
       executable = true;
       text = builtins.readFile "${tmux-sessionizer}/bin/tmux-sessionizer";
-    };
-
-    home.file.".local/bin/tmux-git-status" = lib.mkIf portable {
-      executable = true;
-      text = builtins.readFile "${tmux-git-status}/bin/tmux-git-status";
     };
   };
 }

--- a/modules/home/wt.nix
+++ b/modules/home/wt.nix
@@ -1,0 +1,247 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.myModules.home.wt;
+  portable = config.myModules.home.portable or false;
+  wtWorktreeDir = cfg.worktreeDir or "~/.wt-worktrees";
+in {
+  options.myModules.home.wt = {
+    enable = lib.mkEnableOption "git worktree management (wt function)";
+
+    worktreeDir = lib.mkOption {
+      type = lib.types.str;
+      default = "~/.wt-worktrees";
+      description = "Directory where worktrees are stored";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.fish = {
+      interactiveShellInit = lib.mkAfter ''
+        # ============================================================================
+        # wt - worktree management
+        # ============================================================================
+
+        function __wt_main_root
+          set -l worktrees (command git worktree list --porcelain 2>/dev/null | string match -r '^worktree .+')
+          if test (count $worktrees) -eq 0
+            return 1
+          end
+          string replace -r '^worktree ' "" -- $worktrees[1]
+        end
+
+        function __wt_repo_dir
+          set -l main_root (__wt_main_root)
+          if test -z "$main_root"
+            return 1
+          end
+          printf "%s/%s\n" ${wtWorktreeDir} (basename "$main_root")
+        end
+
+        function __wt_normalize_path
+          if test -z "$argv[1]"
+            return 1
+          end
+          if test -d "$argv[1]"
+            command sh -c 'cd "$1" && pwd -P' sh "$argv[1]"
+          else
+            printf "%s\n" "$argv[1]"
+          end
+        end
+
+        function __wt_random_name
+          set -l left amber ash brisk cedar cinder comet copper ember flint frost harbor ivory juniper maple mist north orbit raven river scout silver solar stone swift timber topo
+          set -l right ant bird bloom brook cloud cove dune field finch flame fox grove hawk leaf meadow moth owl pine reef ridge sparrow star surf trout wave wolf wren
+          printf "%s-%s\n" $left[(random 1 (count $left))] $right[(random 1 (count $right))]
+        end
+
+        function __wt_pick_name
+          set -l repo_dir (__wt_repo_dir)
+          if test -z "$repo_dir"
+            return 1
+          end
+
+          set -l attempts 0
+          while test $attempts -lt 40
+            set attempts (math "$attempts + 1")
+            set -l candidate (__wt_random_name)
+
+            if test -e "$repo_dir/$candidate"
+              continue
+            end
+            if command git show-ref --verify --quiet "refs/heads/$candidate"
+              continue
+            end
+
+            printf "%s\n" "$candidate"
+            return 0
+          end
+
+          while true
+            set -l candidate (__wt_random_name)-(random 100 999)
+            if test -e "$repo_dir/$candidate"
+              continue
+            end
+            if command git show-ref --verify --quiet "refs/heads/$candidate"
+              continue
+            end
+            printf "%s\n" "$candidate"
+            return 0
+          end
+        end
+
+        function __wt_is_registered
+          set -l target (__wt_normalize_path "$argv[1]")
+          if test -z "$target"
+            set target "$argv[1]"
+          end
+          set -l worktrees (command git worktree list --porcelain 2>/dev/null | string match -r '^worktree .+')
+          contains -- "worktree $target" $worktrees
+        end
+
+        function __wt_rename_tmux_window
+          if not set -q TMUX
+            return 0
+          end
+          if not command -sq tmux
+            return 0
+          end
+          command tmux rename-window -- $argv[1] >/dev/null 2>/dev/null
+        end
+
+        function __wt_open
+          set -l name $argv[1]
+          if test -z "$name"
+            echo "wt: missing name" >&2
+            return 1
+          end
+
+          set -l repo_dir (__wt_repo_dir)
+          if test -z "$repo_dir"
+            return 1
+          end
+
+          set -l target "$repo_dir/$name"
+          command mkdir -p -- "$repo_dir"
+
+          if test -d "$target"
+            if __wt_is_registered "$target"
+              cd "$target"
+              or return 1
+              __wt_rename_tmux_window "$name"
+              return 0
+            end
+            echo "wt: $target exists but is not a git worktree" >&2
+            return 1
+          end
+
+          if command git show-ref --verify --quiet "refs/heads/$name"
+            command git worktree add "$target" "$name" >/dev/null
+          else
+            command git worktree add -b "$name" "$target" HEAD >/dev/null
+          end
+          if test $status -ne 0
+            return 1
+          end
+
+          cd "$target"
+          or return 1
+          __wt_rename_tmux_window "$name"
+        end
+
+        function __wt_remove
+          set -l main_root (__wt_main_root)
+          if test -z "$main_root"
+            return 1
+          end
+
+          set -l current_root (command git rev-parse --show-toplevel 2>/dev/null)
+          if test -n "$current_root"
+            set current_root (__wt_normalize_path "$current_root")
+          end
+
+          set -l target
+          if test -n "$argv[1]"
+            if string match -q -- '/*' "$argv[1]"
+              set target "$argv[1]"
+            else
+              set -l repo_dir (__wt_repo_dir)
+              if test -z "$repo_dir"
+                return 1
+              end
+              set target "$repo_dir/$argv[1]"
+            end
+          else
+            if test "$current_root" = "$main_root"
+              echo "wt: give a name or run inside a worktree" >&2
+              return 1
+            end
+            set target "$current_root"
+          end
+
+          set -l normalized_target (__wt_normalize_path "$target")
+          if test -n "$normalized_target"
+            set target "$normalized_target"
+          end
+
+          if test "$target" = "$main_root"
+            echo "wt: refusing to remove main worktree" >&2
+            return 1
+          end
+
+          if not __wt_is_registered "$target"
+            echo "wt: no worktree at $target" >&2
+            return 1
+          end
+
+          set -l inside 0
+          if test "$current_root" = "$target"
+            set inside 1
+          end
+
+          if test $inside -eq 1
+            cd "$main_root"
+            or return 1
+          end
+
+          command git -C "$main_root" worktree remove "$target"
+
+          if test $inside -eq 1
+            __wt_rename_tmux_window (basename "$main_root")
+          end
+        end
+
+        function wt
+          if not command git rev-parse --is-inside-work-tree >/dev/null 2>&1
+            echo "wt: not in a git repo" >&2
+            return 1
+          end
+
+          set -l subcommand "$argv[1]"
+
+          switch "$subcommand"
+            case ""
+              set -l name (__wt_pick_name)
+              if test -z "$name"
+                return 1
+              end
+              __wt_open "$name"
+            case ls list
+              command git worktree list
+            case rm remove
+              __wt_remove $argv[2]
+            case -h --help help
+              echo "usage: wt [name]"
+              echo "       wt ls"
+              echo "       wt rm [name]"
+            case '*'
+              __wt_open "$argv[1]"
+          end
+        end
+      '';
+    };
+  };
+}

--- a/modules/home/wt.nix
+++ b/modules/home/wt.nix
@@ -257,10 +257,15 @@ in {
           end
 
           command git -C "$main_root" worktree remove "$target"
+          set -l remove_status $status
 
-          if test $inside -eq 1
-            __wt_rename_tmux_window (basename "$main_root")
+          if test $remove_status -eq 0
+            if test $inside -eq 1
+              __wt_rename_tmux_window (basename "$main_root")
+            end
           end
+
+          return $remove_status
         end
 
         function wt

--- a/modules/home/wt.nix
+++ b/modules/home/wt.nix
@@ -112,6 +112,48 @@ in {
           command tmux rename-window -- $argv[1] >/dev/null 2>/dev/null
         end
 
+        function __wt_session_name
+          set -l repo_dir $argv[1]
+          set -l target $argv[2]
+
+          if test -z "$repo_dir" -o -z "$target"
+            return 1
+          end
+
+          set -l repo_prefix "$repo_dir/"
+          if string match -q -- "$repo_prefix*" "$target"
+            set -l repo_name (basename "$repo_dir" | string replace -a '.' '_' | string replace -a ' ' '_')
+            set -l worktree_name (basename "$target" | string replace -a '.' '_' | string replace -a ' ' '_')
+            printf "%s/%s\n" $repo_name $worktree_name
+          else
+            basename "$target" | string replace -a '.' '_' | string replace -a ' ' '_'
+          end
+        end
+
+        function __wt_focus_tmux_session
+          set -l name $argv[1]
+          set -l target $argv[2]
+
+          if not command -sq tmux
+            return 1
+          end
+
+          if set -q TMUX
+            if command tmux has-session -t="$name" >/dev/null 2>&1
+              command tmux switch-client -t "$name"
+            else
+              command tmux new-session -ds "$name" -c "$target" >/dev/null
+              command tmux switch-client -t "$name"
+            end
+          else
+            if command tmux has-session -t="$name" >/dev/null 2>&1
+              command tmux attach-session -t "$name"
+            else
+              command tmux new-session -s "$name" -c "$target"
+            end
+          end
+        end
+
         function __wt_open
           set -l name $argv[1]
           if test -z "$name"
@@ -125,13 +167,17 @@ in {
           end
 
           set -l target "$repo_dir/$name"
+          set -l session_name (__wt_session_name "$repo_dir" "$target")
           command mkdir -p -- "$repo_dir"
 
           if test -d "$target"
             if __wt_is_registered "$target"
+              if __wt_focus_tmux_session "$session_name" "$target"
+                return 0
+              end
+
               cd "$target"
               or return 1
-              __wt_rename_tmux_window "$name"
               return 0
             end
             echo "wt: $target exists but is not a git worktree" >&2
@@ -147,9 +193,12 @@ in {
             return 1
           end
 
+          if __wt_focus_tmux_session "$session_name" "$target"
+            return 0
+          end
+
           cd "$target"
           or return 1
-          __wt_rename_tmux_window "$name"
         end
 
         function __wt_remove


### PR DESCRIPTION
- Simplify tmux-sessionizer to ~380 lines (from ~500)
- Add worktree hierarchy display in fzf (parent/child format)
- Add extraPaths option for non-git directories
- Add .tmux-sessionizer sourcing support
- Create standalone wt module for worktree management
- wt creates worktrees in ~/.wt-worktrees/<repo>/
- Add random name generation (e.g., amber-wolf, frost-bird)